### PR TITLE
Fix build error

### DIFF
--- a/src/com/cyanogenmod/eleven/utils/BitmapWithColors.java
+++ b/src/com/cyanogenmod/eleven/utils/BitmapWithColors.java
@@ -19,7 +19,6 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Looper;
 import android.support.v7.graphics.Palette;
-import android.support.v7.graphics.Target;
 import android.util.LruCache;
 
 public class BitmapWithColors {


### PR DESCRIPTION
The error is caused by 

> packages/apps/Eleven/src/com/cyanogenmod/eleven/utils/BitmapWithColors.java:22: The import android.support.v7.graphics.Target cannot be resolved